### PR TITLE
feat: lazy load featured attestations via Nostr subscription

### DIFF
--- a/src/hooks/useFeaturedAttestations.ts
+++ b/src/hooks/useFeaturedAttestations.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { useNostr } from '@nostrify/react';
 import { nip19 } from 'nostr-tools';
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
@@ -7,48 +7,78 @@ import { ATTESTATION_KIND } from '@/lib/attestation';
 
 export function useFeaturedAttestations(naddrs: string[]) {
   const { nostr } = useNostr();
+  const [events, setEvents] = useState<NostrEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
-  return useQuery({
-    queryKey: ['nostr', 'featured-attestations', naddrs],
-    queryFn: async () => {
-      if (naddrs.length === 0) return [];
+  useEffect(() => {
+    if (naddrs.length === 0) {
+      setEvents([]);
+      setIsLoading(false);
+      return;
+    }
 
-      const filters: NostrFilter[] = [];
+    setIsLoading(true);
+    setEvents([]);
 
-      for (const naddr of naddrs) {
-        try {
-          const decoded = nip19.decode(naddr.trim());
-          if (decoded.type === 'naddr' && decoded.data.kind === ATTESTATION_KIND) {
-            filters.push({
-              kinds: [decoded.data.kind],
-              authors: [decoded.data.pubkey],
-              '#d': [decoded.data.identifier],
-              limit: 1,
-            });
-          }
-        } catch {
-          // Ignore invalid naddrs
+    const filters: NostrFilter[] = [];
+
+    for (const naddr of naddrs) {
+      try {
+        const decoded = nip19.decode(naddr.trim());
+        if (decoded.type === 'naddr' && decoded.data.kind === ATTESTATION_KIND) {
+          filters.push({
+            kinds: [decoded.data.kind],
+            authors: [decoded.data.pubkey],
+            '#d': [decoded.data.identifier],
+            limit: 1,
+          });
         }
+      } catch {
+        // Ignore invalid naddrs
       }
+    }
 
-      if (filters.length === 0) return [];
+    if (filters.length === 0) {
+      setIsLoading(false);
+      return;
+    }
 
-      const events = await nostr.query(filters, {
-        signal: AbortSignal.timeout(6000),
-      });
+    let isActive = true;
+    const byD = new Map<string, NostrEvent>();
 
-      // Deduplicate and preserve config order
-      const seen = new Set<string>();
-      const result: NostrEvent[] = [];
+    // Give up the loading state after 8s even if not all events arrived
+    timeoutRef.current = setTimeout(() => {
+      if (isActive) setIsLoading(false);
+    }, 8000);
 
-      for (const event of events) {
-        if (seen.has(event.id)) continue;
-        seen.add(event.id);
-        result.push(event);
+    (async () => {
+      try {
+        const subscription = nostr.req(filters);
+        for await (const msg of subscription) {
+          if (!isActive) break;
+          if (msg[0] !== 'EVENT') continue;
+
+          const event = msg[2];
+          const d = event.tags.find(([name]) => name === 'd')?.[1] ?? event.id;
+
+          const prev = byD.get(d);
+          if (!prev || event.created_at > prev.created_at) {
+            byD.set(d, event);
+            setEvents([...byD.values()]);
+            setIsLoading(false);
+          }
+        }
+      } catch {
+        // Subscription closed or error — noop
       }
+    })();
 
-      return result;
-    },
-    enabled: naddrs.length > 0,
-  });
+    return () => {
+      isActive = false;
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [naddrs, nostr]);
+
+  return { data: events, isLoading };
 }


### PR DESCRIPTION
## Summary
Switches `useFeaturedAttestations` from a one-time `nostr.query()` to a streaming `nostr.req()` subscription so that home page featured attestations appear as relays find them, rather than failing silently when events aren't immediately available.

## Changes
- Replaced `useQuery` + `nostr.query()` with `useEffect` + `nostr.req()` subscription
- Events stream in lazily as relays respond
- Loading state drops after the first event arrives or after an 8s timeout
- Deduplicates by `d` tag and keeps the newest per coordinate